### PR TITLE
Resolve compile errors preventing tests from being run

### DIFF
--- a/shopify/src/fulfillment_service/mod.rs
+++ b/shopify/src/fulfillment_service/mod.rs
@@ -137,6 +137,8 @@ mod tests {
         tracking_support: true,
         requires_shipping_method: true,
         format: "json".to_owned(),
+        permits_sku_sharing: false,
+        fulfillment_orders_opt_in: false,
       })
       .unwrap();
     println!("{:#?}", service);

--- a/shopify/src/order/mod.rs
+++ b/shopify/src/order/mod.rs
@@ -160,7 +160,6 @@ mod tests {
       let id = orders.last().unwrap().get("id").unwrap().as_i64().unwrap();
       println!("count = {}, last_id = {}", orders.len(), id);
 
-      params.page = Some(page + 1);
 
       let f = File::create(format!("{}/order_{}.json", TMP_DIR, page)).unwrap();
       serde_json::to_writer_pretty(f, &orders).unwrap();


### PR DESCRIPTION
Hi @fluxxu,

This PR resolves the remaining compile errors I encountered when trying to run Cargo test:

1. New fields that were recently added in this commit [https://github.com/Ventmere/shopify/commit/d0f763d7bac1587d008c12475e022be359725d45](url)  were breaking the tests in the fulfilment module. I've updated the initialisation of the fulfilment service within the test to include the new fields

2. Within the 'test_dump_all_orders', there was a reference to field called page (params.page). No field `page` on type `order::GetOrderListParams. I've removed this line to resolve the issue.

Following the above two changes, all the tests are now running for me locally

Thanks,

Jian.


