### PR TITLE
Fixed spelling of Wrapper from Warpper

### DIFF
--- a/shopify/src/client/mod.rs
+++ b/shopify/src/client/mod.rs
@@ -17,14 +17,14 @@ macro_rules! shopify_wrap {
       $key:ident: $inner_t:ty$(,)*
     }
   ) => {
-    use crate::client::ShopifyWarpper;
+    use crate::client::ShopifyWrapper;
 
     #[derive(Debug, Deserialize)]
     pub struct $t {
       $key: $inner_t,
     }
 
-    impl ShopifyWarpper<$inner_t> for $t {
+    impl ShopifyWrapper<$inner_t> for $t {
       fn into_inner(self) -> $inner_t {
         self.$key
       }

--- a/shopify/src/client/types.rs
+++ b/shopify/src/client/types.rs
@@ -1,5 +1,5 @@
 #[doc(hidden)]
-pub trait ShopifyWarpper<T> {
+pub trait ShopifyWrapper<T> {
   fn into_inner(self) -> T;
 }
 


### PR DESCRIPTION
ShopifyWrapper contained a spelling error. Rather than being wrapper, it was warpper. This corrects the spelling