### PR TITLE
fix: add `NotEligible` enum variant for order fulfillment status

### DIFF
--- a/shopify/src/order/types.rs
+++ b/shopify/src/order/types.rs
@@ -5,7 +5,8 @@ use crate::types::{DateTime, Utc, Value};
 pub enum FulfillmentStatus {
   Fulfilled,
   Partial,
-  Restocked
+  Restocked,
+  NotEligible,
 }
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]


### PR DESCRIPTION
Hello and thank you for maintaining this crate.

I've recently come onto a crash when customers give a tip. The fulfillment status returned by the Shopify API is `NotEligible`, which is missing from the `FulfillmentStatus` enum.
I don't know why this isn't in the [official Shopify API reference](https://shopify.dev/docs/api/admin-rest/2024-01/resources/order), since the tipping system is integrated directly into Shopify, no addon.

Thanks and have a good day!